### PR TITLE
added cross-env and webpack dependencies for build script on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "@adonisjs/shield": "^1.0.3",
     "@adonisjs/validator": "^4.0.5",
     "@adonisjs/vow": "^1.0.12",
-    "@adonisjs/vow-browser": "^1.0.4",
-    "cross-env": "^5.1.1"
+    "@adonisjs/vow-browser": "^1.0.4"
   },
   "devDependencies": {
     "bootstrap": "^4.0.0-beta.2",
@@ -33,7 +32,8 @@
     "laravel-mix": "^1.6.1",
     "popper.js": "^1.12.5",
     "sqlite3": "^3.1.13",
-    "webpack": "^3.8.1"
+    "webpack": "^3.8.1",
+    "cross-env": "^5.1.1"
   },
   "autoload": {
     "App": "./app"

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "start": "node server.js",
     "test": "node ace test --timeout=0",
-    "build:dev": "NODE_ENV=development webpack --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "build:prod": "NODE_ENV=production webpack --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
+    "build:dev": "cross-env NODE_ENV=development webpack --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "build:prod": "cross-env NODE_ENV=production webpack --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
   },
   "license": "UNLICENSED",
   "private": true,
@@ -24,14 +24,16 @@
     "@adonisjs/shield": "^1.0.3",
     "@adonisjs/validator": "^4.0.5",
     "@adonisjs/vow": "^1.0.12",
-    "@adonisjs/vow-browser": "^1.0.4"
+    "@adonisjs/vow-browser": "^1.0.4",
+    "cross-env": "^5.1.1"
   },
   "devDependencies": {
     "bootstrap": "^4.0.0-beta.2",
     "jquery": "^3.2.1",
     "laravel-mix": "^1.6.1",
     "popper.js": "^1.12.5",
-    "sqlite3": "^3.1.13"
+    "sqlite3": "^3.1.13",
+    "webpack": "^3.8.1"
   },
   "autoload": {
     "App": "./app"


### PR DESCRIPTION
- the cross-env module is needed to run the `build:dev` and `build:prod` scripts on Windows
- Webpack is used but was not explicitly added to the `package.json`
